### PR TITLE
Fix error handling for updating locale

### DIFF
--- a/src/main/java/com/mytaxi/apis/phrase/tasks/PhraseAppSyncTask.java
+++ b/src/main/java/com/mytaxi/apis/phrase/tasks/PhraseAppSyncTask.java
@@ -84,13 +84,7 @@ public class PhraseAppSyncTask implements Runnable
                 {
                     for (final PhraseLocale locale : locales)
                     {
-                        byte[] translationByteArray = localeDownloadAPI.downloadLocale(projectId, locale.getId(), format);
-                        if (translationByteArray == null || translationByteArray.length == 0)
-                        {
-                            LOG.warn("Could not receive any data from PhraseAppApi for locale: {}. Please check configuration in PhraseApp!", locale);
-                            translationByteArray = "no.data.received=true".getBytes();
-                        }
-                        fileService.saveToFile(projectId, translationByteArray, locale.getCode().replace('-', '_'));
+                        updateLocale(projectId, locale);
                     }
                 }
             }
@@ -100,6 +94,25 @@ public class PhraseAppSyncTask implements Runnable
         catch (final Exception e)
         {
             LOG.error("Error due running the PhraseAppSyncTask", e);
+        }
+    }
+
+
+    private void updateLocale(String projectId, PhraseLocale locale)
+    {
+        try
+        {
+            byte[] translationByteArray = localeDownloadAPI.downloadLocale(projectId, locale.getId(), format);
+            if (translationByteArray == null || translationByteArray.length == 0)
+            {
+                LOG.warn("Could not receive any data from PhraseAppApi for locale: {}. Please check configuration in PhraseApp!", locale);
+                translationByteArray = "no.data.received=true".getBytes();
+            }
+            fileService.saveToFile(projectId, translationByteArray, locale.getCode().replace('-', '_'));
+        }
+        catch (Exception e)
+        {
+            LOG.error("Error updating locale {}", locale, e);
         }
     }
 


### PR DESCRIPTION
An error while updating the one locale caused all remaining locales
to no being updated. Adjust the exception handling for a locale to
not cause other locales to fail