### PR TITLE
add test for checking if E-Tag handling is working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.1.6</version>

--- a/src/main/java/com/mytaxi/apis/phrase/api/GenericPhraseAPI.java
+++ b/src/main/java/com/mytaxi/apis/phrase/api/GenericPhraseAPI.java
@@ -141,7 +141,7 @@ public class GenericPhraseAPI<T>
     }
 
 
-    protected T handleResponse(final String projectId, final String requestPath, final ResponseEntity<T> responseEntity) throws PhraseAppApiException
+    public T handleResponse(final String projectId, final String requestPath, final ResponseEntity<T> responseEntity) throws PhraseAppApiException
     {
         T requestedData;
         final HttpStatus statusCode = responseEntity.getStatusCode();

--- a/src/test/java/com/mytaxi/apis/phrase/api/localedownload/DefaultLocaleDownloadAPITest.java
+++ b/src/test/java/com/mytaxi/apis/phrase/api/localedownload/DefaultLocaleDownloadAPITest.java
@@ -3,17 +3,35 @@ package com.mytaxi.apis.phrase.api.localedownload;
 import com.mytaxi.apis.phrase.api.format.Format;
 import com.mytaxi.apis.phrase.api.format.JavaPropertiesFormat;
 import com.mytaxi.apis.phrase.config.TestConfig;
+import java.util.List;
 import org.aeonbits.owner.ConfigFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Created by m.winkelmann on 24.11.15.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class DefaultLocaleDownloadAPITest
 {
+
+    @Captor
+    ArgumentCaptor<ResponseEntity<byte[]>> responseEntityCaptor;
 
     private TestConfig cfg;
 
@@ -40,6 +58,34 @@ public class DefaultLocaleDownloadAPITest
 
         // THEN
         assertNotNull(fileBytes);
+    }
+
+    @Test
+    public void tesDownloadLocales_etag()
+    {
+        // GIVEN
+        String authToken = cfg.authToken();
+        String projectId = cfg.projectId();
+        String localeIdDe = cfg.localeIdDe();
+
+        DefaultPhraseLocaleDownloadAPI localeDownloadAPI = Mockito.spy(new DefaultPhraseLocaleDownloadAPI(authToken));
+
+        // WHEN doing two request
+        byte[] fileBytes1 = localeDownloadAPI.downloadLocale(projectId, localeIdDe);
+        byte[] fileBytes2 = localeDownloadAPI.downloadLocale(projectId, localeIdDe);
+
+        // THEN assert same result
+        assertNotNull(fileBytes1);
+        assertNotNull(fileBytes2);
+        assertEquals(fileBytes1, fileBytes2);
+
+        // AND assert status codes 200 and 304 to verify E-Tag handling
+        verify(localeDownloadAPI, times(2)).handleResponse(eq(projectId), anyString(), responseEntityCaptor.capture());
+        List<ResponseEntity<byte[]>> statusCodes = responseEntityCaptor.getAllValues();
+
+        assertThat(statusCodes)
+            .hasSize(2)
+            .extracting("statusCode").containsExactly(HttpStatus.OK, HttpStatus.NOT_MODIFIED);
     }
 
 


### PR DESCRIPTION
asserting status code 200 for first request and 304 for second request. This is important because 304 is not counting against our rate limits, see https://developers.phraseapp.com/api/#intro "Conditional GET requests / HTTP Caching"